### PR TITLE
fix(99 percent open): Add option to correct 99% open issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This plugin is not affilited with the MySmartBlinds product.
 
 ## notes
 1. Be sure to calibrate your blinds in the 'MySmartBlinds' app if you see that the blinds are not opening perfectly straight
+2. If after calibration you see blinds show as 99% Open (when using automation), set `report99Open` to `true` to see if this helps
 
 ## minimal configuration
 Add to platforms section of homebridge `config.json` after installing the plugin:
@@ -35,6 +36,7 @@ Field                   | Description
 **name**                | Best to set to "MySmartBlindsBridge"
 **username**            | MySmartBlinds app username (usually email address)
 **password**            | MySmartBlinds app password
+**report99Open**        | __(optional, defaults to false)__ Forces plugin to show 99% as open. See note 2 above
 
 ## to-do
 1. Add config option to change direction (from up closed to open)

--- a/index.js
+++ b/index.js
@@ -182,15 +182,35 @@ function MySmartBlindsBridgeAccessory(log, config, blind) {
   this.batteryLevel = blind.batteryLevel;
   this.currentPosition = this.blindPosition;
   this.targetPosition = this.blindPosition;
+  this.report99Open = this.config["report99Open"] || false;
 
   this.positionState = Characteristic.PositionState.STOPPED;
 }
 
 MySmartBlindsBridgeAccessory.prototype = {
+  getCurrentPosition: function (callback) {
+    // using cached current position, rather than fetching actual current position via the API
+    let reportCurrenttPosition = this.currentPosition;
+
+    // if report99Open is true, send 100 even if it is only 99!
+    const check99 = parseInt(reportCurrenttPosition) === 99 && this.report99Open;
+    if (check99) {
+      reportCurrenttPosition = 100;
+    }
+    this.log(`${this.name} getCurrentPosition : ${reportCurrenttPosition}${check99 ? ` (Actual ${this.currentPosition})` : ''}`);
+    callback(null, reportCurrenttPosition);
+  },
   getTargetPosition: function (callback) {
-    this.log(`${this.name} getTargetPosition : ${this.targetPosition}`);
+    let reportTargetPosition = this.targetPosition;
+
+    // if report99Open is true, send 100 even if it is only 99!
+    const check99 = parseInt(reportTargetPosition) === 99 && this.report99Open;
+    if (check99) {
+      reportTargetPosition = 100;
+    }
+    this.log(`${this.name} getTargetPosition : ${reportTargetPosition}${check99 ? ` (Actual ${this.targetPosition})` : ''}`);
     this.service.setCharacteristic(Characteristic.PositionState, Characteristic.PositionState.STOPPED);
-    callback(null, this.targetPosition);
+    callback(null, reportTargetPosition);
   },
   setTargetPosition: function (value, callback) {
     const thisBlind = this;
@@ -259,10 +279,7 @@ MySmartBlindsBridgeAccessory.prototype = {
 
     this.service = new Service.WindowCovering(this.name);
 
-    this.service.getCharacteristic(Characteristic.CurrentPosition).on('get', function (callback) {
-      // using cached current position, rather than fetching actual current position via the API
-      callback(null, this.currentPosition);
-    }.bind(this));
+    this.service.getCharacteristic(Characteristic.CurrentPosition).on('get', this.getCurrentPosition.bind(this));
 
     this.service.getCharacteristic(Characteristic.TargetPosition)
       .on('get', this.getTargetPosition.bind(this))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mysmartblinds-bridge",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-mysmartblinds-bridge",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "homebrige plugin for mysmartblinds",
   "keywords": [
     "homebridge-plugin",


### PR DESCRIPTION
Corrects an issue where after homebridge is restarted the blinds may report as '99% Open' even though they were previously Open.

This is actually an issue with the MySmartBlinds API, but this adds a way to fix it!